### PR TITLE
Exclude peerDependencies when build library

### DIFF
--- a/template/build/webpack.lib.conf.js
+++ b/template/build/webpack.lib.conf.js
@@ -6,6 +6,7 @@ var merge = require('webpack-merge')
 var baseWebpackConfig = require('./webpack.base.conf')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
+var PeerDepsExternalsPlugin = require('peer-deps-externals-webpack-plugin')
 
 var env = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
   ? require('../config/test.env')
@@ -30,6 +31,7 @@ var webpackConfig = merge(baseWebpackConfig, {
     libraryTarget: 'umd'
   },
   plugins: [
+    new PeerDepsExternalsPlugin(),
     // http://vuejs.github.io/vue-loader/en/workflow/production.html
     new webpack.DefinePlugin({
       'process.env': env

--- a/template/package.json
+++ b/template/package.json
@@ -95,18 +95,19 @@
     {{/e2e}}
     "semver": "^5.3.0",
     "shelljs": "^0.7.6",
-    {{#stylus}}   
+    {{#stylus}}
     "stylus": "^0.54.5",
     "stylus-loader": "^3.0.1",
     {{/stylus}}
     "opn": "^5.1.0",
     "optimize-css-assets-webpack-plugin": "^2.0.0",
     "ora": "^1.2.0",
+    "peer-deps-externals-webpack-plugin": "^1.0.2",
     {{#pug}}
     "pug": "^2.0.0-rc.1",
     {{/pug}}
     "rimraf": "^2.6.0",
-    {{#sass}}    
+    {{#sass}}
     "sass-loader": "^6.0.5",
     "node-sass": "^4.5.2",
     {{/sass}}

--- a/template/package.json
+++ b/template/package.json
@@ -20,8 +20,7 @@
     "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs{{/e2e}}"{{/lint}}
   },
   "dependencies": {
-    "vue": "^2.3.3"{{#router}},
-    "vue-router": "^2.6.0"{{/router}}
+    "vue": "^2.3.3"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",
@@ -113,6 +112,9 @@
     {{/sass}}
     "url-loader": "^0.5.8",
     "vue-loader": "^12.1.0",
+    {{#router}}
+    "vue-router": "^2.6.0",
+    {{/router}}
     "vue-style-loader": "^3.0.1",
     "vue-template-compiler": "^2.3.3",
     "webpack": "^2.6.1",


### PR DESCRIPTION
- [x] When build library, `peerDependencies` should be excludes
(https://nodejs.org/en/blog/npm/peer-dependencies/)

In my project, I put `vue` as peerDependencies, so it's not included in build library. This will keep library size is small
https://github.com/ittus/vue-monthly-picker

- [x] `vue-router` should be in deepDependencies. It should not be packed when build library.
